### PR TITLE
Setup delete functionality

### DIFF
--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -24,6 +24,15 @@ const fetchData = {
             body: JSON.stringify(i)
         })
     },
+
+    deleteItem(id) {
+    return fetch(`http://localhost:8088/${id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+  },
 //=========================================     FETCH EDITED CONTENT    =================================================
 
     // getEditedInterests(id) {

--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -3,13 +3,11 @@
 const fetchData = {
     // Use a method to perform a "plug-in" function that will execute fetches with various arguments (a "fetch factory")
     getPlaces() {
-        // places
         return fetch("http://localhost:8088/places")
         .then(place => place.json())
     },
 
     getInterests() {
-    // interests
     // return fetch("http://localhost:8088/interests/?_expand=place")   // What does this mean?
     return fetch("http://localhost:8088/interests")
     .then(interests => interests.json())

--- a/src/scripts/dataTransform.js
+++ b/src/scripts/dataTransform.js
@@ -13,10 +13,10 @@ const createElements = {
         .then(r => {
             // console.log(refreshed);
             let refreshedDataFragment = $("div")    // jQuery creates fragments differently from vanilla JS; in JS, this would be: let refreshedDataFragment = document.createDocumentFragment();
-            r.forEach(s => {
+            r.forEach(entry => {
                 // console.log(s)
-                let sHTML = domAppender.transformData(s)
-                refreshedDataFragment.append(sHTML)
+                let entryHTML = domAppender.transformData(entry)
+                refreshedDataFragment.append(entryHTML)
                 // Translation:
                 // 1. Tap fetchData.getInterests() for the data and return it in the form of "r" so it can be manipulated.
                 // 2. Create a fragment in which to display the data; You will use it later.

--- a/src/scripts/domAppend.js
+++ b/src/scripts/domAppend.js
@@ -2,6 +2,7 @@
 // Build out the HTML elements necessary to capture information the user enters via the form
 
 const domAppender = {
+
     transformData(entry) {
 
         let displayCardsContainer = $("div").attr({"class":"cards-container", "id": "cards-display"})
@@ -26,17 +27,24 @@ const domAppender = {
 
         $("<button>").attr({"id": "edit-btn", "type": "submit"}).text("Edit").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleEdit()})
-        $("<button>").attr({"id": `transformData--${entry.split}`, "type": "submit"}).text("Delete").appendTo(displayCardsContainer)
-        // .click((event) => {event.preventDefault(); editInterest.handleDelete()})
-        // Capture the entry id (from the "places" array in the API) by setting the delete button's attribute id to the entry id so it can be split later.
 
+//======================================    HANDLE DELETE AND CAPTURE ENTRY "ID"    ===============================================
+
+        $("<button>").attr({"class": "delete-btn", "id": `${entry.id}`,"type": "submit"}).text("Delete").appendTo(displayCardsContainer)
+        // In order to capture the "id" value of the API entry in the "places" array,
+        //set the button attribute id like this:
+        // .attr({"id": `${entry.id}`})
+        // When the browser is refreshed and the button element inspected, the "id" will be equal to the first entry's id (in this case, it shows id=1)
+
+
+//=================================================================================================================================
         $("<button>").attr({"id": "save-btn", "type": "submit"}).text("Save").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleSave()})
         // The .click is for the edit form later; the modele and methods have not been created yet
 
 
         return displayCardsContainer    // You have to include a "return"!
-    }
+
 //======================================  TRANSFORM-HTML METHOD FOR EDITED CONTENT =====================================================
 // Create a method that loops through getInterests and builds display cards for edited content; ideally, it will reuse the original form
 
@@ -48,6 +56,6 @@ const domAppender = {
     // }
 
     // return displayEditedContainer
+    }
 }
-
 export default domAppender

--- a/src/scripts/domAppend.js
+++ b/src/scripts/domAppend.js
@@ -2,7 +2,7 @@
 // Build out the HTML elements necessary to capture information the user enters via the form
 
 const domAppender = {
-    transformData(s) {
+    transformData(entry) {
 
         let displayCardsContainer = $("div").attr({"class":"cards-container", "id": "cards-display"})
         // console.log(displayCardsContainer);
@@ -17,17 +17,19 @@ const domAppender = {
         // review if it's not blank and
         // the place it is located
 
-        $("<h4>").text(s.name).appendTo(displayCardsContainer)
-        $("<p>").text(s.description).appendTo(displayCardsContainer)
-        $("<p>").text(s.place).appendTo(displayCardsContainer)
-        $("<p>").attr({"id":"cost", "contentEditable": false}).text(s.cost).appendTo(displayCardsContainer)
+        $("<h4>").text(entry.name).appendTo(displayCardsContainer)
+        $("<p>").text(entry.description).appendTo(displayCardsContainer)
+        $("<p>").text(entry.place).appendTo(displayCardsContainer)
+        $("<p>").attr({"id":"cost", "contentEditable": false}).text(entry.cost).appendTo(displayCardsContainer) // I want to use contentEditable to change this to an editable field upon "click"
         // It is not necessary to declare a variable before creating and appending the elements; jQuery doesn't care about that.
         // Therefore, this: let cardContentDesc = $("<p>").attr({"id": "card-content-desc"}).appendTo(displayCardsContainer) is incorrect for jQ.
 
         $("<button>").attr({"id": "edit-btn", "type": "submit"}).text("Edit").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleEdit()})
-        $("<button>").attr({"id": "delete-btn", "type": "submit"}).text("Delete").appendTo(displayCardsContainer)
+        $("<button>").attr({"id": `transformData--${entry.split}`, "type": "submit"}).text("Delete").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleDelete()})
+        // Capture the entry id (from the "places" array in the API) by setting the delete button's attribute id to the entry id so it can be split later.
+
         $("<button>").attr({"id": "save-btn", "type": "submit"}).text("Save").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleSave()})
         // The .click is for the edit form later; the modele and methods have not been created yet


### PR DESCRIPTION
Sought to capture the value of an entry's database id via the delete button (in the cards display) in order to manipulate entries in the database directly. 

- Updated attributes on the delete button from ```$("<button>").attr({"id": "delete-btn"....}).``` to ```${(<"button">).attr({"id": `${entry.id}`.....})  and added a class ("delete-btn"). 
- Inspecting the delete button after browser refresh gave ```id=1```. 
- To confirm whether "places" or "interests" array was selected, the "interests" database id entry was changed from 1 to 4 and the button was inspected again. 
- Confirmed that `$(entry.id}` corresponds to the value of the "interest" key in database.json. 