### PR TITLE
Working with ids

### DIFF
--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -13,8 +13,8 @@ const fetchData = {
     .then(interests => interests.json())
     },
 
-    postPlaces(i) {
-        return fetch("http://localhost:8088/places", {
+    postInterest(i) {
+        return fetch("http://localhost:8088/interests", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"

--- a/src/scripts/dataTransform.js
+++ b/src/scripts/dataTransform.js
@@ -8,13 +8,13 @@ import domAppender from "./domAppend"
 const createElements = {
     refreshData() {
 
-        // fetchData.getPlaces()    // Using getPlaces() generates an error.
-        fetchData.getInterests()
+        fetchData.getPlaces()    // Using getPlaces() generates an error.
+        // fetchData.getInterests()
         .then(r => {
             // console.log(refreshed);
             let refreshedDataFragment = $("div")    // jQuery creates fragments differently from vanilla JS; in JS, this would be: let refreshedDataFragment = document.createDocumentFragment();
             r.forEach(entry => {
-                console.log(entry)
+                // console.log(entry)
                 let entryHTML = domAppender.transformData(entry)
                 refreshedDataFragment.append(entryHTML)
                 // Translation:
@@ -28,7 +28,7 @@ const createElements = {
             })
             refreshedDataFragment.appendTo("#cards-display")    // append the fragment to the DOM
         })
-    },
+    }
 
 //======================================  REFRESH EDITED DATA    =====================================================
 // Tap

--- a/src/scripts/dataTransform.js
+++ b/src/scripts/dataTransform.js
@@ -14,7 +14,7 @@ const createElements = {
             // console.log(refreshed);
             let refreshedDataFragment = $("div")    // jQuery creates fragments differently from vanilla JS; in JS, this would be: let refreshedDataFragment = document.createDocumentFragment();
             r.forEach(entry => {
-                // console.log(s)
+                console.log(entry)
                 let entryHTML = domAppender.transformData(entry)
                 refreshedDataFragment.append(entryHTML)
                 // Translation:

--- a/src/scripts/domAppend.js
+++ b/src/scripts/domAppend.js
@@ -25,7 +25,9 @@ const domAppender = {
         // It is not necessary to declare a variable before creating and appending the elements; jQuery doesn't care about that.
         // Therefore, this: let cardContentDesc = $("<p>").attr({"id": "card-content-desc"}).appendTo(displayCardsContainer) is incorrect for jQ.
 
-        $("<button>").attr({"id": "edit-btn", "type": "submit"}).text("Edit").appendTo(displayCardsContainer)
+//============================================      EDIT BUTTON     =====================================================================
+
+        $("<button>").attr({"id": "edit-btn","type": "submit"}).text("Edit").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleEdit()})
 
 //======================================    HANDLE DELETE AND CAPTURE ENTRY "ID"    ===============================================
@@ -36,12 +38,14 @@ const domAppender = {
         // .attr({"id": `${entry.id}`})
         // When the browser is refreshed and the button element inspected, the "id" will be equal to the first entry's id (in this case, it shows id=1)
 
-
-//=================================================================================================================================
+//============================================      SAVE BUTTON     =====================================================================================
+// The save button needs to trigger a handler that sends PATCH to the API and updates the cards display
+ 
         $("<button>").attr({"id": "save-btn", "type": "submit"}).text("Save").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleSave()})
-        // The .click is for the edit form later; the modele and methods have not been created yet
+        // The .click is for the edit form later; the module and methods have not been created yet
 
+//=================================================================================================================================
 
         return displayCardsContainer    // You have to include a "return"!
 

--- a/src/scripts/domAppend.js
+++ b/src/scripts/domAppend.js
@@ -40,7 +40,7 @@ const domAppender = {
 
 //============================================      SAVE BUTTON     =====================================================================================
 // The save button needs to trigger a handler that sends PATCH to the API and updates the cards display
- 
+
         $("<button>").attr({"id": "save-btn", "type": "submit"}).text("Save").appendTo(displayCardsContainer)
         // .click((event) => {event.preventDefault(); editInterest.handleSave()})
         // The .click is for the edit form later; the module and methods have not been created yet

--- a/src/scripts/form.js
+++ b/src/scripts/form.js
@@ -52,19 +52,18 @@ handleNewInterest(event) {
 
 
     // write a loop that looks for the id and records it's value
-        let newObj = {
-            placeId: "",
+        let newEventObj = {
+
             name: $("#name-field").val(),   // When using jQ, you .val() is a method; in vanilla JS, .value is sufficient.
             description: $("#desc-field").val(),
             cost: $("#cost-field").val(),
             place: $("#place-field").val(),
-            review: $("#review-field").val(),
-            id: `${id}`
+            review: $("#review-field").val()
             //The review should not be visible until the user enters it (via the "edit") feature on the display card.
         }
 
-        // fetchData.postInterests(newObj)  // Using postInterests() generates an error.
-        fetchData.postPlaces(newObj)    // Calling the postPlaces() method here sends the data in the landing page form to the "places" array.
+        // fetchData.postInterests(newEventObj)
+        fetchData.postInterest(newEventObj)
         .then(p => {
         })
     }


### PR DESCRIPTION
- Fixed an issue where API were incorrectly referenced; Places were being posted in a limitless fashion but there was only one interest. Now, multiple interests can be added. Further testing for bugs is needed to ensure there are no issues with "places".
- Currently the display cards are visible on load. This is fine for now, given that Santiago, Buenos Aires and Rio de Janero are in the database but more testing is needed to ensure the correct items are visible on page load. 
- The delete buttons on the place cards are referencing the correct database ids for places now! 